### PR TITLE
Added compatibility with C++

### DIFF
--- a/src/ntru.h
+++ b/src/ntru.h
@@ -1,6 +1,10 @@
 #ifndef NTRU_NTRU_H
 #define NTRU_NTRU_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus*/
+
 #include "types.h"
 #include "key.h"
 #include "encparams.h"
@@ -70,5 +74,9 @@ uint8_t ntru_decrypt(uint8_t *enc, NtruEncKeyPair *kp, NtruEncParams *params, ui
  * @return the maximum number of bytes in a message
  */
 uint8_t ntru_max_msg_len(NtruEncParams *params);
+
+#ifdef __cplusplus
+}
+#endif /* __cplusplus*/
 
 #endif   /* NTRU_NTRU_H */


### PR DESCRIPTION
I wanted to use your libntru implementation in my project, but was unable to link to it from c++ code. adding these little wrappers did the job. It would be good to have them in mainstream I think.