### PR TITLE
Build on macOS Sierra fails

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,12 @@
 # Object files
 *.o
 
+libntru.dylib
+libntru.dylib.dSYM
+testham
+testham.dSYM
+testnoham.dSYM
+
 # Compiler-generated assembly files
 src/sha1-mb-x86_64.s
 src/sha256-mb-x86_64.s

--- a/Changes.md
+++ b/Changes.md
@@ -1,0 +1,11 @@
+
+Modifications on Sun Jul 16 19:44:38 MDT 2017
+
+Added check for `__clang__` in a number of files so that this will compile with the
+standard cc shipped with MacOS.
+
+Fixed problem #37 with it not working on MacOS due to incorrect extern's for 
+global variables.
+
+TODO: Because it is not using special instructions in CLang it is much slower.
+

--- a/README.md
+++ b/README.md
@@ -24,6 +24,15 @@ The ```SIMD``` environment variable controls SSSE3 and AVX2 support.
 The default is ```auto``` which means SSSE3 and AVX2 are detected at runtime.
 Other values are ```none```, ```ssse3```, and ```avx2```.
 
+**Note** On macOS Sierra Version 10.12.5/Apple LLVM version 8.1.0 (clang-802.0.42) You
+must set the SIMD environment to ssse3 (export SIMD=ssse3) before running make as
+or make will break due to **error: use of unknown builtin '__builtin_cpu_init'** 
+message. Build as follows:
+
+```
+export SIMD=ssse3; make all
+```
+
 If the ```NTRU_AVOID_HAMMING_WT_PATENT``` preprocessor flag is supplied, the library won't support
 parameter sets that will be patent encumbered after Aug 19, 2017. See the *Parameter Sets* section
 for information on patent expiration dates.

--- a/README.md
+++ b/README.md
@@ -24,10 +24,12 @@ The ```SIMD``` environment variable controls SSSE3 and AVX2 support.
 The default is ```auto``` which means SSSE3 and AVX2 are detected at runtime.
 Other values are ```none```, ```ssse3```, and ```avx2```.
 
-**Note** On macOS Sierra Version 10.12.5/Apple LLVM version 8.1.0 (clang-802.0.42) You
-must set the SIMD environment to ssse3 (export SIMD=ssse3) before running make as
-or make will break due to **error: use of unknown builtin '__builtin_cpu_init'** 
-message. Build as follows:
+### Building on macOS Sierra
+On macOS Sierra Version 10.12.5/Apple LLVM version 8.1.0 (clang-802.0.42) you
+must set the SIMD environment to ssse3 (export SIMD=ssse3) before running make or the build will break due to **error: use of unknown builtin '__builtin_cpu_init'** 
+message. 
+
+Build as follows:
 
 ```
 export SIMD=ssse3; make all

--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ Build as follows:
 export SIMD=ssse3; make all
 ```
 
+### Flag to account for encumbered patent
+
 If the ```NTRU_AVOID_HAMMING_WT_PATENT``` preprocessor flag is supplied, the library won't support
 parameter sets that will be patent encumbered after Aug 19, 2017. See the *Parameter Sets* section
 for information on patent expiration dates.

--- a/src/hash.c
+++ b/src/hash.c
@@ -80,6 +80,8 @@ void ntru_sha256_8way_nosimd(uint8_t *input[8], uint16_t input_len, uint8_t *dig
 
 void ntru_set_optimized_impl_hash() {
 #ifdef NTRU_DETECT_SIMD
+#ifdef __clang__
+#else
     if (__builtin_cpu_supports("ssse3") || __builtin_cpu_supports("avx2")) {
         ntru_sha1_4way_ptr = ntru_sha1_4way_simd;
         ntru_sha256_4way_ptr = ntru_sha256_4way_simd;
@@ -90,7 +92,9 @@ void ntru_set_optimized_impl_hash() {
             OPENSSL_ia32cap_P[2] = 1<<5;
         }
     }
-    else {
+    else
+#endif
+	{
         ntru_sha1_4way_ptr = ntru_sha1_4way_nosimd;
         ntru_sha256_4way_ptr = ntru_sha256_4way_nosimd;
         ntru_sha1_8way_ptr = ntru_sha1_8way_nosimd;

--- a/src/ntru.c
+++ b/src/ntru.c
@@ -48,7 +48,10 @@ const int8_t NTRU_COEFF2_TABLE[] = {0, 1, -1, 0, 1, -1, 0, 1};
 
 void ntru_set_optimized_impl() {
 #ifdef NTRU_DETECT_SIMD
+#ifdef __clang__
+#else
     __builtin_cpu_init();
+#endif
 #endif
     ntru_set_optimized_impl_poly();
     ntru_set_optimized_impl_hash();

--- a/src/poly.h
+++ b/src/poly.h
@@ -135,7 +135,7 @@ void ntru_sub(NtruIntPoly *a, NtruIntPoly *b);
  * @param mod_mask an AND mask to apply; must be a power of two minus one
  * @return 0 if the number of coefficients differ, 1 otherwise
  */
-uint8_t (*ntru_mult_tern)(NtruIntPoly *a, NtruTernPoly *b, NtruIntPoly *c, uint16_t mod_mask);
+extern uint8_t (*ntru_mult_tern)(NtruIntPoly *a, NtruTernPoly *b, NtruIntPoly *c, uint16_t mod_mask);
 
 /**
  * @brief General polynomial by ternary polynomial multiplication, 32 bit version
@@ -236,7 +236,7 @@ void ntru_to_arr_64(NtruIntPoly *p, uint16_t q, uint8_t *a);
  * @param q the modulus; must be a power of two
  * @param a output parameter; a pointer to store the encoded polynomial
  */
-void (*ntru_to_arr)(NtruIntPoly *p, uint16_t q, uint8_t *a);
+extern void (*ntru_to_arr)(NtruIntPoly *p, uint16_t q, uint8_t *a);
 
 /**
  * @brief Polynomial to binary modulo 4
@@ -273,7 +273,7 @@ void ntru_mult_fac(NtruIntPoly *a, int16_t factor);
  * @param mod_mask an AND mask to apply to the coefficients of c
  * @return 0 if the number of coefficients differ, 1 otherwise
  */
-uint8_t (*ntru_mult_int)(NtruIntPoly *a, NtruIntPoly *b, NtruIntPoly *c, uint16_t mod_mask);
+extern uint8_t (*ntru_mult_int)(NtruIntPoly *a, NtruIntPoly *b, NtruIntPoly *c, uint16_t mod_mask);
 
 /**
  * @brief Multiplication of two general polynomials with a modulus
@@ -313,7 +313,7 @@ uint8_t ntru_mult_int_64(NtruIntPoly *a, NtruIntPoly *b, NtruIntPoly *c, uint16_
  * @param p input and output parameter; coefficients are overwritten
  * @param mod_mask an AND mask to apply to the coefficients of c
  */
-void (*ntru_mod_mask)(NtruIntPoly *p, uint16_t mod_mask);
+extern void (*ntru_mod_mask)(NtruIntPoly *p, uint16_t mod_mask);
 
 /**
  * @brief Reduction modulo 3
@@ -379,7 +379,7 @@ void ntru_clear_int(NtruIntPoly *p);
  * @param Fq output parameter; a pointer to store the new polynomial
  * @return 1 if a is invertible, 0 otherwise
  */
-uint8_t (*ntru_invert)(NtruPrivPoly *a, uint16_t mod_mask, NtruIntPoly *Fq);
+extern uint8_t (*ntru_invert)(NtruPrivPoly *a, uint16_t mod_mask, NtruIntPoly *Fq);
 
 /**
  * @brief Inverse modulo q


### PR DESCRIPTION
SIMD must be specified before running make or the make process will fail. Added a few lines to make this a bit more clear.