### PR TITLE
src/ntru_endian.h: Fix FTBFS bug on big-endian arches for GLIBC >= 2.9

### DIFF
--- a/src/ntru_endian.h
+++ b/src/ntru_endian.h
@@ -18,7 +18,7 @@
 #endif
 
 #ifdef __GLIBC__
-#if __GLIBC__ <= 2 || ( __GLIBC__ == 2 && __GLIBC_MINOR__ < 9 )
+#if __GLIBC__ < 2 || ( __GLIBC__ == 2 && __GLIBC_MINOR__ < 9 )
 #ifndef __powerpc__
 /* assume little endian */
 #define htole64(x) (x)


### PR DESCRIPTION
The original code override those functions when GLIBC >= 2.9.
We should check GLIBC version < 2.9 and only provide the byte-order
convertion functions when needed.

Signed-off-by: Ying-Chun Liu (PaulLiu) <paulliu@debian.org>