### PR TITLE
Fix crashes on macOS, and updates for macOS Sierra and newer

### DIFF
--- a/Makefile.osx
+++ b/Makefile.osx
@@ -35,7 +35,7 @@ ifneq ($(SIMD), none)
 endif
 TEST_OBJS=test_bitstring.o test_hash.o test_idxgen.o test_key.o test_ntruprime.o test_ntru.o test.o test_poly.o test_util.o
 VERSION=0.5
-INST_PFX=/usr
+INST_PFX=/opt/local
 INST_LIBDIR=$(INST_PFX)/lib
 INST_INCLUDE=$(INST_PFX)/include/libntru
 INST_DOCDIR=$(INST_PFX)/share/doc/libntru

--- a/Makefile.osx
+++ b/Makefile.osx
@@ -60,14 +60,14 @@ install: lib
 	test -d "$(DESTDIR)$(INST_LIBDIR)" || mkdir "$(DESTDIR)$(INST_LIBDIR)"
 	test -d "$(DESTDIR)$(INST_INCLUDE)" || mkdir -p "$(DESTDIR)$(INST_INCLUDE)"
 	test -d "$(DESTDIR)$(INST_DOCDIR)" || mkdir -p "$(DESTDIR)$(INST_DOCDIR)"
-	install -m 0755 libntru.so "$(DESTDIR)$(INST_LIBDIR)/libntru.so"
+	install -m 0755 libntru.dylib "$(DESTDIR)$(INST_LIBDIR)/libntru.dylib"
 	install -m 0644 README.md "$(DESTDIR)$(INST_DOCDIR)/README.md"
 	for header in $(INST_HEADERS) ; do \
 	    install -m 0644 "$(SRCDIR)/$$header" "$(DESTDIR)$(INST_INCLUDE)/" ; \
 	done
 
 uninstall:
-	rm -f "$(DESTDIR)$(INST_LIBDIR)/libntru.so"
+	rm -f "$(DESTDIR)$(INST_LIBDIR)/libntru.dylib"
 	rm -f "$(DESTDIR)$(INST_DOCDIR)/README.md"
 	rmdir "$(DESTDIR)$(INST_DOCDIR)/"
 	for header in $(INST_HEADERS) ; do \

--- a/src/bench.c
+++ b/src/bench.c
@@ -2,6 +2,10 @@
 #include <stdlib.h>
 #include <time.h>
 #include "ntru.h"
+#if defined(__APPLE__)
+#include <Availability.h>
+#include <AvailabilityMacros.h>
+#endif /* __APPLE__ */
 
 #define NUM_ITER_KEYGEN 50
 #define NUM_ITER_ENCDEC 10000
@@ -14,11 +18,13 @@
 #ifdef __MACH__
 
 /*
- * Mac OS X does not have clock_gettime for some reason
+ * Mac OS X prior to 10.12 does not have clock_gettime for some reason
  *
  * Use solution from here to fix it:
  * http://stackoverflow.com/questions/5167269/clock-gettime-alternative-in-mac-os-x
  */
+
+#if !(defined(__APPLE__) && defined(__MAC_OS_X_VERSION_MIN_REQUIRED) && (__MAC_OS_X_VERSION_MIN_REQUIRED >= 101200))
 
 #define CLOCK_REALTIME 0
 
@@ -38,6 +44,7 @@ the_time->tv_sec = mts.tv_sec;
 the_time->tv_nsec = mts.tv_nsec;
 }
 
+#endif /* not ( __APPLE__ and macOS is 10.12 or newer) */
 #endif /* __MACH__ */
 
 #ifdef __MINGW32__

--- a/src/poly.c
+++ b/src/poly.c
@@ -1,3 +1,4 @@
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <alloca.h>
@@ -12,6 +13,12 @@
 
 #define NTRU_KARATSUBA_THRESH_16 40
 #define NTRU_KARATSUBA_THRESH_64 120
+
+void (*ntru_to_arr)(NtruIntPoly *p, uint16_t q, uint8_t *a);
+uint8_t (*ntru_mult_tern)(NtruIntPoly *a, NtruTernPoly *b, NtruIntPoly *c, uint16_t mod_mask);
+uint8_t (*ntru_mult_int)(NtruIntPoly *a, NtruIntPoly *b, NtruIntPoly *c, uint16_t mod_mask);
+void (*ntru_mod_mask)(NtruIntPoly *p, uint16_t mod_mask);
+uint8_t (*ntru_invert)(NtruPrivPoly *a, uint16_t mod_mask, NtruIntPoly *Fq);
 
 /***************************************
  *          NTRU Prime                 *

--- a/src/poly.h
+++ b/src/poly.h
@@ -135,7 +135,7 @@ void ntru_sub(NtruIntPoly *a, NtruIntPoly *b);
  * @param mod_mask an AND mask to apply; must be a power of two minus one
  * @return 0 if the number of coefficients differ, 1 otherwise
  */
-uint8_t (*ntru_mult_tern)(NtruIntPoly *a, NtruTernPoly *b, NtruIntPoly *c, uint16_t mod_mask);
+extern uint8_t (*ntru_mult_tern)(NtruIntPoly *a, NtruTernPoly *b, NtruIntPoly *c, uint16_t mod_mask);
 
 /**
  * @brief General polynomial by ternary polynomial multiplication, 32 bit version
@@ -236,7 +236,7 @@ void ntru_to_arr_64(NtruIntPoly *p, uint16_t q, uint8_t *a);
  * @param q the modulus; must be a power of two
  * @param a output parameter; a pointer to store the encoded polynomial
  */
-void (*ntru_to_arr)(NtruIntPoly *p, uint16_t q, uint8_t *a);
+extern void (*ntru_to_arr)(NtruIntPoly *p, uint16_t q, uint8_t *a);
 
 /**
  * @brief Polynomial to binary modulo 4
@@ -273,7 +273,7 @@ void ntru_mult_fac(NtruIntPoly *a, int16_t factor);
  * @param mod_mask an AND mask to apply to the coefficients of c
  * @return 0 if the number of coefficients differ, 1 otherwise
  */
-uint8_t (*ntru_mult_int)(NtruIntPoly *a, NtruIntPoly *b, NtruIntPoly *c, uint16_t mod_mask);
+extern uint8_t (*ntru_mult_int)(NtruIntPoly *a, NtruIntPoly *b, NtruIntPoly *c, uint16_t mod_mask);
 
 /**
  * @brief Multiplication of two general polynomials with a modulus
@@ -313,7 +313,7 @@ uint8_t ntru_mult_int_64(NtruIntPoly *a, NtruIntPoly *b, NtruIntPoly *c, uint16_
  * @param p input and output parameter; coefficients are overwritten
  * @param mod_mask an AND mask to apply to the coefficients of c
  */
-void (*ntru_mod_mask)(NtruIntPoly *p, uint16_t mod_mask);
+extern void (*ntru_mod_mask)(NtruIntPoly *p, uint16_t mod_mask);
 
 /**
  * @brief Reduction modulo 3
@@ -379,7 +379,7 @@ void ntru_clear_int(NtruIntPoly *p);
  * @param Fq output parameter; a pointer to store the new polynomial
  * @return 1 if a is invertible, 0 otherwise
  */
-uint8_t (*ntru_invert)(NtruPrivPoly *a, uint16_t mod_mask, NtruIntPoly *Fq);
+extern uint8_t (*ntru_invert)(NtruPrivPoly *a, uint16_t mod_mask, NtruIntPoly *Fq);
 
 /**
  * @brief Inverse modulo q


### PR DESCRIPTION
This PR fixes #46 and a few other problems on macOS that I did not bother to report (yet).
It's been tested on macOS Catalina 10.15.6 (current stable release).

Tested with Xcode-11.6 Clang, Clang-10, and GCC-10. 
Note: my env is configured with `AS_INTEGRATED_ASSEMBLER=1` to use Xcode-provided assembler, as GAS isn't even fully anymore.